### PR TITLE
codegen: make collection aliases (Map/List/Set/…) type-check and construct

### DIFF
--- a/compiler/impl/codegen/decl.xi
+++ b/compiler/impl/codegen/decl.xi
@@ -5,9 +5,24 @@
 // An alias whose target is an array/optional type (e.g. `type People = Person[]`).
 // These reference xc_arr_*/xc_opt_* and so must be emitted AFTER those typedefs
 // (see genAliasTypedefs); they are skipped by the array/opt/result/refined passes.
+// True if the C base type is a container monomorphization (array, or a
+// collection alias like xc_Map_*/xc_List_*). Such aliases must be emitted after
+// genArrTypedefs, which defines those underlying typedefs.
+predicate isCollectionCtype(b: String) {
+    return b.startsWith2("xc_arr_")
+        or b.startsWith2("xc_Map_")
+        or b.startsWith2("xc_List_")
+        or b.startsWith2("xc_Set_")
+        or b.startsWith2("xc_Stack_")
+        or b.startsWith2("xc_Queue_")
+        or b.startsWith2("xc_SortedQueue_")
+        or b.startsWith2("xc_Future_")
+        or b.startsWith2("xc_Query_")
+}
+
 predicate isCompositeAlias(ts: TypeSpec) {
     if ts.isCompound { return false }
-    return ts.baseCtype.startsWith2("xc_arr_")
+    return isCollectionCtype(ts.baseCtype)
 }
 
 mapper genRefinedTypedefs(prog: Program) -> String {

--- a/compiler/impl/codegen/expr.xi
+++ b/compiler/impl/codegen/expr.xi
@@ -166,6 +166,67 @@ mapper hoistLambdas(prog: Program, toks: Token[], tag: String) -> String {
 }
 
 // ── primary ───────────────────────────────────────────────────────
+// Reverse of ctypeSuffix (parser/type_parser.xi): a container-name suffix back to
+// its C base type, so `empty <collection-alias>` can rebuild the constructor.
+mapper suffixToCtype(suf: String) -> String {
+    if suf == "number" { return "xc_number_t" }
+    if suf == "integer" { return "xc_integer_t" }
+    if suf == "bool" { return "xc_bool_t" }
+    if suf == "string" { return "xc_string_t" }
+    if suf == "char" { return "xc_char_t" }
+    if suf == "size" { return "xc_size_t" }
+    if suf == "timestamp" { return "xc_timestamp_t" }
+    return "xc_" + suf + "_t"
+}
+
+// Length of the (single-word) map-key suffix at the front of `mid`, or -1.
+mapper mapKeySuffixLen(mid: String) -> Integer {
+    if mid.startsWith2("string_") { return 6 }
+    if mid.startsWith2("integer_") { return 7 }
+    if mid.startsWith2("number_") { return 6 }
+    if mid.startsWith2("bool_") { return 4 }
+    if mid.startsWith2("char_") { return 4 }
+    if mid.startsWith2("size_") { return 4 }
+    if mid.startsWith2("timestamp_") { return 9 }
+    return 0 - 1
+}
+
+// The runtime constructor for a collection base ctype (xc_Map_*/xc_List_*/…), or
+// "" when `base` is not a collection. Mirrors the `empty Map<...>` / `empty
+// List<...>` codegen so an alias of a collection builds a real value rather than
+// a zeroed struct that crashes on first use.
+mapper collectionCtor(base: String) -> String {
+    if base.startsWith2("xc_Map_") {
+        let mid = string_slice(base, 7, string_len(base) - 2)
+        let klen = mapKeySuffixLen(mid)
+        if klen < 0 { return "" }
+        let kc = suffixToCtype(string_slice(mid, 0, klen))
+        let vc = suffixToCtype(string_slice(mid, klen + 1, string_len(mid)))
+        return "xstd_map_new(sizeof(" + kc + "), sizeof(" + vc + "), " + kc.strFlagFor() + ")"
+    }
+    if base.startsWith2("xc_List_") {
+        let ec = suffixToCtype(string_slice(base, 8, string_len(base) - 2))
+        return "xstd_list_new(sizeof(" + ec + "))"
+    }
+    if base.startsWith2("xc_Set_") {
+        let ec = suffixToCtype(string_slice(base, 7, string_len(base) - 2))
+        return "xstd_set_new(sizeof(" + ec + "), " + ec.strFlagFor() + ")"
+    }
+    if base.startsWith2("xc_Stack_") {
+        let ec = suffixToCtype(string_slice(base, 9, string_len(base) - 2))
+        return "xstd_stack_new(sizeof(" + ec + "))"
+    }
+    if base.startsWith2("xc_Queue_") {
+        let ec = suffixToCtype(string_slice(base, 9, string_len(base) - 2))
+        return "xstd_queue_new(sizeof(" + ec + "))"
+    }
+    if base.startsWith2("xc_SortedQueue_") {
+        let ec = suffixToCtype(string_slice(base, 15, string_len(base) - 2))
+        return "xstd_pqueue_new(sizeof(" + ec + "), " + ec.pqCmpKind() + ")"
+    }
+    return ""
+}
+
 mapper genPrimary(toks: Token[], pos: Integer, ctx: GCtx) -> ExprRes {
     let k = toks.kindAt(pos)
     let txt = toks.textAt(pos)
@@ -410,6 +471,17 @@ mapper genPrimary(toks: Token[], pos: Integer, ctx: GCtx) -> ExprRes {
                 else { if pk == 126 { tp = tp + 1 }                            // !
                 else { if pk == 104 and toks.kindAt(tp + 1) == 105 { tp = tp + 2 }  // []
                 else { cont = false } } }
+            }
+            // A bare `empty <alias>` where the alias targets a collection: build
+            // the real constructor, not a zeroed struct that crashes on first use.
+            if nk == 1 and tp == pos + 2 {
+                let ts = findTypeSpec(ctx.prog, toks.textAt(pos + 1))
+                if string_len(ts.name) > 0 and not ts.isCompound and not ts.isSum {
+                    let ctor = collectionCtor(ts.baseCtype)
+                    if string_len(ctor) > 0 {
+                        return ExprRes { code: ctor, pos: tp, xtyp: string_slice(ts.baseCtype, 3, string_len(ts.baseCtype) - 2) , owned: false }
+                    }
+                }
             }
             return ExprRes { code: "(" + ctype + "){0}", pos: tp, xtyp: toks.textAt(pos + 1) , owned: false }
         }

--- a/examples/language/collection_alias_test.xi
+++ b/examples/language/collection_alias_test.xi
@@ -1,0 +1,43 @@
+// Regression: an alias of a collection (type M = Map<K,V>, etc.) now both
+// type-checks (its underlying monomorphized typedef is emitted after it is
+// defined) and constructs via `empty M` (a real constructor, not a zeroed struct
+// that used to crash at first use).
+type User    = { name: String, age: Integer }
+type UserMap = Map<String, User>       // compound value
+type IntMap  = Map<String, Integer>    // primitive value
+type Names   = List<String>
+type Tags    = Set<String>
+
+test "empty of a Map alias with a compound value works" {
+    let m = empty UserMap
+    m.put("ada", User { name: "Ada", age: 36 })
+    m.put("bo", User { name: "Bo", age: 20 })
+    assertEq(m.len(), 2)
+    assertEq(m.get("ada").age, 36)
+}
+
+test "empty of a Map alias with a primitive value works" {
+    let m = empty IntMap
+    m.put("a", 5)
+    m.put("a", 7)                       // overwrite
+    assertEq(m.get("a"), 7)
+    assertEq(m.getOr("z", -1), 0 - 1)
+}
+
+test "empty of a List alias works" {
+    let ns = empty Names
+    ns.push("x")
+    ns.push("y")
+    assertEq(ns.len(), 2)
+    assertEq(ns.get(0), "x")
+}
+
+test "empty of a Set alias dedups" {
+    let t = empty Tags
+    t.add("a")
+    t.add("a")
+    t.add("b")
+    assertEq(t.len(), 2)
+}
+
+module App {}


### PR DESCRIPTION
Two coupled bugs made a collection alias (`type M = Map<K, V>`, `List<T>`, `Set<T>`, `Stack<T>`, …) unusable, and the second one was a silent runtime crash.

## Bugs

1. **Typedef ordering** — `genRefinedTypedefs` emitted `typedef xc_Map_string_User_t xc_M_t;` before `genArrTypedefs` defined the underlying `xc_Map_string_User_t`, so a compound value gave `unknown type name`.
2. **Silent null-struct** — `empty M` emitted a zeroed `(xc_M_t){0}` (a null map/list with no backing storage) that compiled fine and then crashed at first `.put`/`.get`. Fixing (1) alone would have turned the compile error into this silent runtime crash, so they had to be fixed together.

## Fix

1. `isCompositeAlias` now defers **any** collection-ctype alias (`xc_Map_`, `xc_List_`, `xc_Set_`, …) to `genAliasTypedefs`, which runs after the monomorphization typedefs exist — exactly how `xc_arr_` aliases were already handled.
2. `genPrimary` resolves a bare `empty <collection-alias>` to the real runtime constructor (`xstd_map_new` / `xstd_list_new` / `xstd_set_new` / …), reconstructing the element ctypes from the alias base type (the key suffix is always a single known word, so the split is unambiguous).

```
type UserMap = Map<String, User>
let m = empty UserMap           // now a real map, was a null struct
m.put("ada", User { name: "Ada", age: 36 })
```

## Verification

- Regression test `examples/language/collection_alias_test.xi` (Map with compound + primitive values, List, Set).
- Probed edge cases: alias as class `state`, `Stack`/`Set` aliases, nested `Map<String, List<Integer>>` — all work.
- Self-host fixpoint holds (gen2 == gen3); all 46 existing test files pass.